### PR TITLE
Swap the places of Documentation selectors

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -43,12 +43,12 @@ return array(
         ),
         'selectors' => array(
             'Documentation' => array(
-                'ZF\Apigility\Documentation\JsonModel' => array(
-                    'application/json',
-                ),
                 'Zend\View\Model\ViewModel' => array(
                     'text/html',
                     'application/xhtml+xml',
+                ),
+                'ZF\Apigility\Documentation\JsonModel' => array(
+                    'application/json',
                 ),
             ),
         ),


### PR DESCRIPTION
I have an integration scenario of embedding Internet Explorer to display
Apigility. If I click on the API Docs button then IE downloads a
documentation.json file instead of navigating to the Apigility
Documentation page. For some reason the /apigility/documentation API
returns an application/json response instead of text/html.

If I swap the places of the selectors then everything works fine.
