### PR TITLE
Added support for namespaced API names.

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -14,7 +14,7 @@ return array(
                         'options' => array(
                             'route'    => '/documentation[/:api[-v:version][/:service]]',
                             'constraints' => array(
-                                'api' => '[a-zA-Z][a-zA-Z0-9_]+',
+                                'api' => '[a-zA-Z][a-zA-Z0-9_\.]+',
                             ),
                             'defaults' => array(
                                 'controller' => 'ZF\Apigility\Documentation\Controller',

--- a/src/ApiFactory.php
+++ b/src/ApiFactory.php
@@ -77,7 +77,7 @@ class ApiFactory
                 }
 
                 $apigilityModules[] = array(
-                    'name'     => $moduleName,
+                    'name'     => str_replace('\\', '.', $moduleName),
                     'versions' => $versions,
                 );
             }
@@ -97,6 +97,8 @@ class ApiFactory
         $api = new Api;
 
         $api->setVersion($apiVersion);
+
+        $apiName = str_replace('.', '\\', $apiName);
         $api->setName($apiName);
 
         $serviceConfigs = array();

--- a/test/ApiFactoryTest.php
+++ b/test/ApiFactoryTest.php
@@ -148,6 +148,17 @@ class ApiFactoryTest extends TestCase
         $this->assertCount(4, $api->getServices());
     }
 
+    public function testCreateNamespacedApi()
+    {
+        $api = $this->apiFactory->createApi('Test.Api', 1);
+        $this->assertInstanceOf('ZF\Apigility\Documentation\Api', $api);
+
+        $this->assertEquals('Test\\Api', $api->getName());
+        $this->assertEquals(1, $api->getVersion());
+        $this->assertCount(4, $api->getServices());
+        // TODO: $api will be empty at this point because there's no config for it in the module config files
+    }
+
     public function testCreateRestService()
     {
         $docConfig = include __DIR__ . '/TestAsset/module-config/documentation.config.php';


### PR DESCRIPTION
This PR adds support for namespaced API names. An API may have a namespaced name if the module is loaded through a PSR-4 autoloader. 

For example the API may be namespaced: "Company\\Project1Api". If that's the case, the zf-apigility-documentation module doesn't handle the API name properly and among other issues this causes navigating to the API's documentation impossible. 