### PR TITLE
Added type to field documentation

### DIFF
--- a/src/ApiFactory.php
+++ b/src/ApiFactory.php
@@ -107,6 +107,8 @@ class ApiFactory
             $serviceConfigs = array_merge($serviceConfigs, $this->config['zf-rpc']);
         }
 
+
+
         foreach ($serviceConfigs as $serviceName => $serviceConfig) {
             if (strpos($serviceName, $apiName . '\\') === 0
                 && strpos($serviceName, '\V' . $api->getVersion() . '\\')
@@ -118,6 +120,8 @@ class ApiFactory
                 }
             }
         }
+
+
 
         return $api;
     }
@@ -202,6 +206,9 @@ class ApiFactory
                     $field->setName($fieldData['name']);
                     if (isset($fieldData['description'])) {
                         $field->setDescription($fieldData['description']);
+                    }
+                    if (isset($fieldData['type'])) {
+                        $field->setType($fieldData['type']);
                     }
                     $field->setRequired($fieldData['required']);
                 }

--- a/src/Field.php
+++ b/src/Field.php
@@ -27,6 +27,11 @@ class Field implements IteratorAggregate
     protected $required = false;
 
     /**
+     * @var string
+     */
+    protected $type = 'string';
+
+    /**
      * @param string $name
      */
     public function setName($name)
@@ -75,6 +80,22 @@ class Field implements IteratorAggregate
     }
 
     /**
+     * @param string $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
      * Cast object to array
      *
      * @return array
@@ -84,6 +105,7 @@ class Field implements IteratorAggregate
         return array(
             'description' => $this->description,
             'required' => $this->required,
+            'type' => $this->type,
         );
     }
 

--- a/view/zf-apigility-documentation/operation.phtml
+++ b/view/zf-apigility-documentation/operation.phtml
@@ -25,6 +25,7 @@ $collapseId     = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $service
                     <thead>
                         <tr>
                             <th>Field</th>
+                            <th>Type</th>
                             <th>Description</th>
                             <th class="center-block">Required</th>
                         </tr>
@@ -33,6 +34,7 @@ $collapseId     = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $service
                     <?php foreach ($fields as $field): ?>
                         <tr>
                             <td><?php echo $this->escapeHtml($field->getName()) ?></td>
+                            <td><?php echo $this->escapeHtml($field->getType()) ?></td>
                             <td><?php echo $this->escapeHtml($field->getDescription()) ?></td>
                             <td class="center-block"><span class="badge"><?php echo ($field->isRequired()) ? 'YES' : 'NO' ?></td>
                         </tr>


### PR DESCRIPTION
Swagger has support for datatypes (currently the Swagger apigility module defaults to string because this module does not provide datatypes). I've added support for a `type` key (next to `description`) in `input_filter_specs` config entries. Also submitted a tiny update to https://github.com/zfcampus/zf-apigility-documentation-swagger to pick this change up (https://github.com/zfcampus/zf-apigility-documentation-swagger/pull/9). 