### PR TITLE
Support nested namespace in API name

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -14,7 +14,7 @@ return array(
                         'options' => array(
                             'route'    => '/documentation[/:api[-v:version][/:service]]',
                             'constraints' => array(
-                                'api' => '[a-zA-Z][a-zA-Z0-9_]+',
+                                'api' => '[a-zA-Z][a-zA-Z0-9_.]+',
                             ),
                             'defaults' => array(
                                 'controller' => 'ZF\Apigility\Documentation\Controller',

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -41,7 +41,7 @@ class Controller extends AbstractActionController
      */
     public function showAction()
     {
-        $apiName = $this->params()->fromRoute('api');
+        $apiName = $this->normalizeApiName($this->params()->fromRoute('api'));
         $apiVersion = $this->params()->fromRoute('version', '1');
         $serviceName = $this->params()->fromRoute('service');
 
@@ -69,4 +69,13 @@ class Controller extends AbstractActionController
         $viewModel->setVariable('type', 'service');
         return $viewModel;
     }
+
+	/**
+	 * @param $name
+	 * @return mixed
+	 */
+	protected function normalizeApiName($name)
+	{
+		return str_replace('.', '\\', $name);
+	}
 }

--- a/view/zf-apigility-documentation/api-list.phtml
+++ b/view/zf-apigility-documentation/api-list.phtml
@@ -19,7 +19,7 @@
                     return sprintf(
                         '<a href="%s">v%s</a>',
                         $view->url('zf-apigility/documentation', array(
-                            'api'     => $name,
+                            'api'     => str_replace('\\', '.', $name),
                             'version' => $version
                         )),
                         $view->escapeHtml($version)


### PR DESCRIPTION
Hi,
I had some troubles accessing the auto generated documentation for REST APIs, which use nested namespaces. By default Apigility creates new APIs without any preceding namespace, like this:
"ApiName\\V1\\MyApi\\MyApiResource"
But it supports APIs with deeper namespaces (like "Company\\Rest\\ApiName\\V1\\MyApi\\MyApiResource") as well.
Even in the admin/settings UI where namespace separator are converted to a dot like this:
https://myApigility.dev/apigility/ui#/api/Company.Rest.ApiName/v1/rest-services?view=settings

You can see that conversion for example in \ZF\Apigility\Admin\Model\VersioningModelFactory::normalizeModuleName()

But: nested namespaces are not supported in the documentation module, generated URLs look like this:
https://myApigility.dev/apigility/documentation/Company\Rest\ApiName-v1
=> breaks routing and leads to a 404.

My questions are: Is that on purpose? Is there any reason for this behavior? And is there another way to achieve my goal (support APIs with deeper namespace nesting) without the attached code changes?

My pull request includes a quick way to fix that, but as I don't know the reason for the original behavior, I have no idea whether this might break anything else (including backward compatibility).

Any feedback is highly appreciated. And thanks for that great product!