### PR TITLE
Zend\ModuleManager\ModuleManager can not be created. Use ModuleManager

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -32,7 +32,7 @@ class Module implements AutoloaderProviderInterface, ConfigProviderInterface
         return array('factories' => array(
             'ZF\Apigility\Documentation\ApiFactory' => function ($services) {
                     return new ApiFactory(
-                        $services->get('Zend\ModuleManager\ModuleManager'),
+                        $services->get('ModuleManager'),
                         $services->get('Config'),
                         $services->get('ZF\Configuration\ModuleUtils')
                     );


### PR DESCRIPTION
Service locator can not create Zend\ModuleManager\ModuleManager, because there is no factory, that can handle this alias. The factory, which can create module manager in the right way is in MVC module, and can be called just with 'ModuleManager', without the full namespace