### PR TITLE
Rendering documentation is raising errors

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -239,7 +239,7 @@ class Service implements IteratorAggregate
      */
     public function getFields($type)
     {
-        return $this->fields[$type];
+        return isset($this->fields[$type]) ? $this->fields[$type] : array();
     }
 
     /**
@@ -260,15 +260,22 @@ class Service implements IteratorAggregate
         );
 
         $fields = array();
-        foreach ($this->fields['input_filter'] as $field) {
-            $fields['input_filter'][$field->getName()] = $field->toArray();
+        if (isset($this->fields['input_filter'])) {
+            foreach ($this->fields['input_filter'] as $field) {
+                $fields['input_filter'][$field->getName()] = $field->toArray();
+            }
         }
+
         $operations = array();
         foreach ($this->operations as $op) {
             $method = $op->getHttpMethod();
-            foreach ($this->fields[$method] as $field) {
-                $fields[$method][$field->getName()] = $field->toArray();
+
+            if (isset($this->fields[$method])) {
+                foreach ($this->fields[$method] as $field) {
+                    $fields[$method][$field->getName()] = $field->toArray();
+                }
             }
+
             $operations[$method] = $op->toArray();
         }
         $output['fields'] = $fields;

--- a/view/zf-apigility-documentation/operation.phtml
+++ b/view/zf-apigility-documentation/operation.phtml
@@ -36,7 +36,7 @@ $collapseId        = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $serv
                     if (is_array($generalFields)):
                         foreach ($generalFields as $field): ?>
                             <tr>
-                                <td>ss<?php echo $this->escapeHtml($field->getName()) ?></td>
+                                <td><?php echo $this->escapeHtml($field->getName()) ?></td>
                                 <td><?php echo $this->escapeHtml($field->getType() ?: '') ?></td>
                                 <td><?php echo $this->escapeHtml($field->getDescription()) ?></td>
                                 <td class="center-block"><span class="badge"><?php echo ($field->isRequired()) ? 'YES' : 'NO' ?></td>


### PR DESCRIPTION
I'm seeing a number of "index not found" errors when rendering the documentation; these all appear to be due to fetching fields, typically by HTTP method, sometimes from the general input filter. The end result is either a screenful of errors (if display_errors is enabled), or empty field information.

Additionally, if/when fields are rendered, they are prefixed with the text "ss".