### PR TITLE
Add Markdown support in descriptions + sort services

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ scripts.
   view representation of the route configuration of a service path.
 - `ZF\Apigility\Documentation\View\AgStatusCodes` (a.k.a `agStatusCodes`) for making an
   escaped list of status codes and their messages.
+- `ZF\Apigility\Documentation\View\AgTransformDescription` (a.k.a `agTransformDescription`) for transforming the written 
+  descriptions into Markdown.
 
 ### Factories
 

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     },
     "require": {
         "php": ">=5.5",
+        "michelf/php-markdown" : "^1.5",
         "zendframework/zend-modulemanager": "~2.3",
         "zendframework/zend-mvc": "~2.3",
         "zendframework/zend-servicemanager": "~2.3",

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -55,10 +55,11 @@ return array(
     ),
     'view_helpers' => array(
         'invokables' => array(
-            'agacceptheaders'      => 'ZF\Apigility\Documentation\View\AgAcceptHeaders',
-            'agcontenttypeheaders' => 'ZF\Apigility\Documentation\View\AgContentTypeHeaders',
-            'agservicepath'        => 'ZF\Apigility\Documentation\View\AgServicePath',
-            'agstatuscodes'        => 'ZF\Apigility\Documentation\View\AgStatusCodes',
+            'agacceptheaders'         => 'ZF\Apigility\Documentation\View\AgAcceptHeaders',
+            'agcontenttypeheaders'    => 'ZF\Apigility\Documentation\View\AgContentTypeHeaders',
+            'agservicepath'           => 'ZF\Apigility\Documentation\View\AgServicePath',
+            'agstatuscodes'           => 'ZF\Apigility\Documentation\View\AgStatusCodes',
+            'agtransformdescription'  => 'ZF\Apigility\Documentation\View\AgTransformDescription',
         ),
     ),
     'view_manager' => array(

--- a/src/ApiFactory.php
+++ b/src/ApiFactory.php
@@ -107,6 +107,9 @@ class ApiFactory
             $serviceConfigs = array_merge($serviceConfigs, $this->config['zf-rpc']);
         }
 
+        // Sort services by name
+        ksort($serviceConfigs);
+
         foreach ($serviceConfigs as $serviceName => $serviceConfig) {
             if (strpos($serviceName, $apiName . '\\') === 0
                 && strpos($serviceName, '\V' . $api->getVersion() . '\\')

--- a/src/View/AgTransformDescription.php
+++ b/src/View/AgTransformDescription.php
@@ -11,9 +11,9 @@ use \Michelf\Markdown;
 use Zend\View\Helper\AbstractHelper;
 
 /**
- * View helper used to transform a raw Apigility description into a specific format (only Markdown is currently 
- * supported). 
- * 
+ * View helper used to transform a raw Apigility description into a specific format (only Markdown is currently
+ * supported).
+ *
  * @see https://github.com/michelf/php-markdown
  */
 class AgTransformDescription extends AbstractHelper
@@ -26,6 +26,6 @@ class AgTransformDescription extends AbstractHelper
      */
     public function __invoke($description)
     {
-    	return Markdown::defaultTransform($description);
+        return Markdown::defaultTransform($description);
     }
 }

--- a/src/View/AgTransformDescription.php
+++ b/src/View/AgTransformDescription.php
@@ -6,7 +6,7 @@
 
 namespace ZF\Apigility\Documentation\View;
 
-use \Michelf\Markdown;
+use \Michelf\MarkdownExtra;
 
 use Zend\View\Helper\AbstractHelper;
 
@@ -26,6 +26,6 @@ class AgTransformDescription extends AbstractHelper
      */
     public function __invoke($description)
     {
-        return Markdown::defaultTransform($description);
+        return MarkdownExtra::defaultTransform($description);
     }
 }

--- a/src/View/AgTransformDescription.php
+++ b/src/View/AgTransformDescription.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility\Documentation\View;
+
+use \Michelf\Markdown;
+
+use Zend\View\Helper\AbstractHelper;
+
+/**
+ * View helper used to transform a raw Apigility description into a specific format (only Markdown is currently 
+ * supported). 
+ * 
+ * @see https://github.com/michelf/php-markdown
+ */
+class AgTransformDescription extends AbstractHelper
+{
+    /**
+     * Transform an Apigility raw description into a specific format (only Markdown is currently supported).
+     *
+     * @param  string $string The raw Apigility description.
+     * @return string The resulting transformed description.
+     */
+    public function __invoke($description)
+    {
+    	return Markdown::defaultTransform($description);
+    }
+}

--- a/view/zf-apigility-documentation/operation.phtml
+++ b/view/zf-apigility-documentation/operation.phtml
@@ -18,7 +18,7 @@ $collapseId        = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $serv
 
         <div class="panel-collapse collapse" id="<?php echo $collapseId ?>">
             <div class="panel-body">
-                <p class="text-muted"><?php echo $this->escapeHtml($operation->getDescription()) ?></p>
+                <p class="text-muted"><?php echo $this->agTransformDescription($operation->getDescription()) ?></p>
 
                 <?php if (! empty($generalFields) ||  ! empty($httpMethodFields)): ?>
                 <h4>Fields</h4>
@@ -38,7 +38,7 @@ $collapseId        = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $serv
                             <tr>
                                 <td><?php echo $this->escapeHtml($field->getName()) ?></td>
                                 <td><?php echo $this->escapeHtml($field->getType() ?: '') ?></td>
-                                <td><?php echo $this->escapeHtml($field->getDescription()) ?></td>
+                                <td><?php echo $this->escapeTransformDescription($field->getDescription()) ?></td>
                                 <td class="center-block"><span class="badge"><?php echo ($field->isRequired()) ? 'YES' : 'NO' ?></td>
                             </tr>
                         <?php
@@ -51,7 +51,7 @@ $collapseId        = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $serv
                             <tr>
                                 <td><?php echo $this->escapeHtml($field->getName()) ?></td>
                                 <td><?php echo $this->escapeHtml($field->getType() ?: '') ?></td>
-                                <td><?php echo $this->escapeHtml($field->getDescription()) ?></td>
+                                <td><?php echo $this->agTransformDescription($field->getDescription()) ?></td>
                                 <td class="center-block"><span class="badge"><?php echo ($field->isRequired()) ? 'YES' : 'NO' ?></td>
                             </tr>
                         <?php

--- a/view/zf-apigility-documentation/service.phtml
+++ b/view/zf-apigility-documentation/service.phtml
@@ -14,7 +14,7 @@ $serviceCollapseId = $this->escapeHtmlAttr(sprintf('docs-collapse-%s', $service-
 
     <div class="panel-collapse collapse<?php echo ($this->embedded) ? '' : ' in' ?>" id="<?php echo $serviceCollapseId ?>">
         <div class="panel-body">
-            <p class="text-muted"><?php echo $this->escapeHtml($service->getDescription()) ?></p>
+            <p class="text-muted"><?php echo $this->agTransformDescription($service->getDescription()) ?></p>
         </div>
 
         <?php foreach ($service->getOperations() as $operation) {


### PR DESCRIPTION
**Fix for issue #34**

I also tried to do the same in `zf-apigility-documentation` but their at too much css styles overwritings in swagger to make it work without too much modifications.

Please note that this add a new View Helper `agTransformDescription($description)`, if this pull request is accespted the documentation (https://apigility.org/documentation/api-doc/customize) should be updated too. 

This view helper could be customized to support several formats if needed.

**Fix for issue #36**

Simply call to `ksort`.