### PR TITLE
Fix #37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor/
+.idea/

--- a/src/ApiFactory.php
+++ b/src/ApiFactory.php
@@ -401,6 +401,10 @@ class ApiFactory
             $field->setType($fieldData['type']);
         }
 
+        if (isset($fieldData['field_type'])) {
+            $field->setFieldType($fieldData['field_type']);
+        }
+
         $required = isset($fieldData['required']) ? (bool) $fieldData['required'] : false;
         $field->setRequired($required);
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -32,6 +32,11 @@ class Field implements IteratorAggregate
     protected $type = null;
 
     /**
+     * @var string
+     */
+    protected $fieldType = '';
+
+    /**
      * @param string $name
      */
     public function setName($name)
@@ -96,6 +101,22 @@ class Field implements IteratorAggregate
     }
 
     /**
+     * @return string
+     */
+    public function getFieldType()
+    {
+        return $this->fieldType;
+    }
+
+    /**
+     * @param string $fieldType
+     */
+    public function setFieldType($fieldType)
+    {
+        $this->fieldType = $fieldType;
+    }
+
+    /**
      * Cast object to array
      *
      * @return array
@@ -105,7 +126,7 @@ class Field implements IteratorAggregate
         return [
             'description' => $this->description,
             'required' => $this->required,
-            'type' => $this->type,
+            'type' => $this->fieldType,
         ];
     }
 

--- a/view/zf-apigility-documentation/operation.phtml
+++ b/view/zf-apigility-documentation/operation.phtml
@@ -37,7 +37,7 @@ $collapseId        = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $serv
                         foreach ($generalFields as $field): ?>
                             <tr>
                                 <td><?php echo $this->escapeHtml($field->getName()) ?></td>
-                                <td><?php echo $this->escapeHtml($field->getType() ?: '') ?></td>
+                                <td><?php echo $this->escapeHtml($field->getFieldType() ?: '') ?></td>
                                 <td><?php echo $this->escapeHtml($field->getDescription()) ?></td>
                                 <td class="center-block"><span class="badge"><?php echo ($field->isRequired()) ? 'YES' : 'NO' ?></td>
                             </tr>
@@ -50,7 +50,7 @@ $collapseId        = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $serv
                         foreach ($httpMethodFields as $field): ?>
                             <tr>
                                 <td><?php echo $this->escapeHtml($field->getName()) ?></td>
-                                <td><?php echo $this->escapeHtml($field->getType() ?: '') ?></td>
+                                <td><?php echo $this->escapeHtml($field->getFieldType() ?: '') ?></td>
                                 <td><?php echo $this->escapeHtml($field->getDescription()) ?></td>
                                 <td class="center-block"><span class="badge"><?php echo ($field->isRequired()) ? 'YES' : 'NO' ?></td>
                             </tr>


### PR DESCRIPTION
Added a dedicated property for Field objects to support 'type' documentation without causing a BC break.
<img width="1180" alt="capture d ecran 2015-09-26 a 11 33 37" src="https://cloud.githubusercontent.com/assets/5320213/10117025/9a342d16-6448-11e5-8a1c-89b5e43ac376.png">
