### PR TITLE
generate docs for \Zend\InputFilter\CollectionInputFilter type

### DIFF
--- a/src/ApiFactory.php
+++ b/src/ApiFactory.php
@@ -371,6 +371,15 @@ class ApiFactory
         $flatFields = [];
 
         foreach ($fields as $idx => $field) {
+            if (isset($field['type'])
+                && ($field['type'] === \Zend\InputFilter\CollectionInputFilter::class
+                    || is_subclass_of($field['type'], \Zend\InputFilter\CollectionInputFilter::class))
+                && isset($field['input_filter'])) {
+                $filteredFields = array_diff_key($field['input_filter'], ['type' => 0]);
+                $fullindex = $prefix ? sprintf('%s[]/%s', $prefix, $idx) : $idx . '[]';
+                $flatFields = array_merge($flatFields, $this->mapFields($filteredFields, $fullindex));
+                continue;
+            }
             if (isset($field['type']) && is_subclass_of($field['type'], 'Zend\InputFilter\InputFilterInterface')) {
                 $filteredFields = array_diff_key($field, ['type' => 0]);
                 $fullindex = $prefix ? sprintf('%s/%s', $prefix, $idx) : $idx;

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -20,7 +20,7 @@ class Controller extends AbstractActionController
     /**
      * @var ServerUrl
      */
-     protected $serverUrlViewHelper;
+    protected $serverUrlViewHelper;
 
     /**
      * @param ApiFactory $apiFactory

--- a/test/ApiFactoryTest.php
+++ b/test/ApiFactoryTest.php
@@ -148,7 +148,7 @@ class ApiFactoryTest extends TestCase
 
         $this->assertEquals('Test', $api->getName());
         $this->assertEquals(1, $api->getVersion());
-        $this->assertCount(4, $api->getServices());
+        $this->assertCount(5, $api->getServices());
     }
 
     public function testCreateRestService()
@@ -220,6 +220,27 @@ class ApiFactoryTest extends TestCase
                     break;
             }
         }
+    }
+
+    public function testCreateRestServiceWithCollection()
+    {
+        $docConfig = include __DIR__ . '/TestAsset/module-config/documentation.config.php';
+        $api = $this->apiFactory->createApi('Test', 1);
+
+        $service = $this->apiFactory->createService($api, 'FooBarCollection');
+        $this->assertInstanceOf('ZF\Apigility\Documentation\Service', $service);
+
+        $this->assertEquals('FooBarCollection', $service->getName());
+        $this->assertEquals(
+            $docConfig['Test\V1\Rest\FooBarCollection\Controller']['description'],
+            $service->getDescription()
+        );
+
+        $fields = $service->getFields('input_filter');
+        $this->assertCount(2, $fields);
+
+        $this->assertSame('FooBarCollection[]/FooBar', $fields[0]->getName());
+        $this->assertSame('AnotherCollection[]/FooBar', $fields[1]->getName());
     }
 
     public function testCreateRpcService()

--- a/test/TestAsset/module-config/documentation.config.php
+++ b/test/TestAsset/module-config/documentation.config.php
@@ -75,6 +75,9 @@ return array(
         ),
         'description' => 'Some general notes about the FooBar rest service',
     ),
+    'Test\\V1\\Rest\\FooBarCollection\\Controller' => array(
+        'description' => 'Some general notes about the FooBarCollection rest service',
+    ),
     'Test\\V1\\Rpc\\Ping\\Controller' => array(
         'GET' => array(
             'description' => 'Ping the API to see uptime and network lag',

--- a/test/TestAsset/module-config/module.config.php
+++ b/test/TestAsset/module-config/module.config.php
@@ -16,6 +16,15 @@ return array(
                     ),
                 ),
             ),
+            'test.rest.foo-bar-collection' => array(
+                'type' => 'Segment',
+                'options' => array(
+                    'route' => '/foo-bar-collection[/:foo_bar_collection_id]',
+                    'defaults' => array(
+                        'controller' => 'Test\\V1\\Rest\\FooBarCollection\\Controller',
+                    ),
+                ),
+            ),
             'test.rest.boo-baz' => array(
                 'type' => 'Segment',
                 'options' => array(
@@ -53,11 +62,13 @@ return array(
             1 => 'test.rest.boo-baz',
             2 => 'test.rpc.my-rpc',
             3 => 'test.rpc.ping',
+            4 => 'test.rest.foo-bar-collection',
         ),
     ),
     'service_manager' => array(
         'invokables' => array(
             'Test\\V1\\Rest\\FooBar\\FooBarResource' => 'Test\\V1\\Rest\\FooBar\\FooBarResource',
+            'Test\\V1\\Rest\\FooBarCollection\\FooBarResource' => 'Test\\V1\\Rest\\FooBarCollection\\FooBarResource',
             'Test\\V1\\Rest\\BooBaz\\BooBazResource' => 'Test\\V1\\Rest\\BooBaz\\BooBazResource',
         ),
     ),
@@ -83,6 +94,28 @@ return array(
             'entity_class' => 'Test\\V1\\Rest\\FooBar\\FooBarEntity',
             'collection_class' => 'Test\\V1\\Rest\\FooBar\\FooBarCollection',
             'service_name' => 'FooBar',
+        ),
+        'Test\\V1\\Rest\\FooBarCollection\\Controller' => array(
+            'listener' => 'Test\\V1\\Rest\\FooBarCollection\\FooBarResource',
+            'route_name' => 'test.rest.foo-bar-collection',
+            'route_identifier_name' => 'foo_bar_collectio_id',
+            'collection_name' => 'foo_bar_collection',
+            'entity_http_methods' => array(
+                0 => 'GET',
+                1 => 'PATCH',
+                2 => 'PUT',
+                3 => 'DELETE',
+            ),
+            'collection_http_methods' => array(
+                0 => 'GET',
+                1 => 'POST',
+            ),
+            'collection_query_whitelist' => array(),
+            'page_size' => 25,
+            'page_size_param' => null,
+            'entity_class' => 'Test\\V1\\Rest\\FooBarCollection\\FooBarEntity',
+            'collection_class' => 'Test\\V1\\Rest\\FooBarCollection\\FooBarCollection',
+            'service_name' => 'FooBarCollection',
         ),
         'Test\\V1\\Rest\\BooBaz\\Controller' => array(
             'listener' => 'Test\\V1\\Rest\\BooBaz\\BooBazResource',
@@ -110,12 +143,18 @@ return array(
     'zf-content-negotiation' => array(
         'controllers' => array(
             'Test\\V1\\Rest\\FooBar\\Controller' => 'HalJson',
+            'Test\\V1\\Rest\\FooBarCollection\\Controller' => 'HalJson',
             'Test\\V1\\Rest\\BooBaz\\Controller' => 'HalJson',
             'Test\\V1\\Rpc\\MyRpc\\Controller' => 'Json',
             'Test\\V1\\Rpc\\Ping\\Controller' => 'Json',
         ),
         'accept_whitelist' => array(
             'Test\\V1\\Rest\\FooBar\\Controller' => array(
+                0 => 'application/vnd.test.v1+json',
+                1 => 'application/hal+json',
+                2 => 'application/json',
+            ),
+            'Test\\V1\\Rest\\FooBarCollection\\Controller' => array(
                 0 => 'application/vnd.test.v1+json',
                 1 => 'application/hal+json',
                 2 => 'application/json',
@@ -138,6 +177,10 @@ return array(
         ),
         'content_type_whitelist' => array(
             'Test\\V1\\Rest\\FooBar\\Controller' => array(
+                0 => 'application/vnd.test.v1+json',
+                1 => 'application/json',
+            ),
+            'Test\\V1\\Rest\\FooBarCollection\\Controller' => array(
                 0 => 'application/vnd.test.v1+json',
                 1 => 'application/json',
             ),
@@ -209,6 +252,9 @@ return array(
         'Test\\V1\\Rest\\FooBar\\Controller' => array(
             'input_filter' => 'Test\\V1\\Rest\\FooBar\\Validator',
         ),
+        'Test\\V1\\Rest\\FooBarCollection\\Controller' => array(
+            'input_filter' => 'Test\\V1\\Rest\\FooBarCollection\\Validator',
+        ),
     ),
     'input_filter_specs' => array(
         'Test\\V1\\Rest\\FooBar\\Validator' => array(
@@ -271,6 +317,32 @@ return array(
                 ),
             ),
         ),
+        'Test\\V1\\Rest\\FooBarCollection\\Validator' => array(
+            'FooBarCollection' => array(
+                'type' => Zend\InputFilter\CollectionInputFilter::class,
+                'required' => true,
+                'count' => 1,
+                'input_filter' => array(
+                    'type' => Zend\InputFilter\InputFilter::class,
+                    'name' => 'FooBar',
+                    'required' => true,
+                    'filters' => array(),
+                    'validators' => array(),
+                ),
+            ),
+            'AnotherCollection' => array(
+                'type' => 'Zend\\InputFilter\\CollectionInputFilter',
+                'required' => true,
+                'count' => 1,
+                'input_filter' => array(
+                    'type' => Zend\InputFilter\InputFilter::class,
+                    'name' => 'FooBar',
+                    'required' => true,
+                    'filters' => array(),
+                    'validators' => array(),
+                ),
+            ),
+        ),
     ),
     'zf-mvc-auth' => array(
         'authentication' => array(
@@ -281,6 +353,22 @@ return array(
         ),
         'authorization' => array(
             'Test\V1\Rest\FooBar\Controller' => array(
+                'entity' => array(
+                    'DELETE' => true,
+                    'GET'    => false,
+                    'PATCH'  => true,
+                    'POST'   => false,
+                    'PUT'    => true,
+                ),
+                'collection' => array(
+                    'DELETE' => false,
+                    'GET'    => false,
+                    'PATCH'  => false,
+                    'POST'   => true,
+                    'PUT'    => false,
+                ),
+            ),
+            'Test\V1\Rest\FooBarCollection\Controller' => array(
                 'entity' => array(
                     'DELETE' => true,
                     'GET'    => false,


### PR DESCRIPTION
input_filter_spec configuration supports collections: https://github.com/zendframework/zend-inputfilter/blob/master/src/Factory.php#L318

the following input_filter_spec is acceptable for input validation, but generates an error in documentation:
```
return array(
    'input_filter_specs' => array(
        'Test\\V1\\Rest\\FooBarCollection\\Validator' => array(
            'FooBarCollection' => array(
                'type' => Zend\InputFilter\CollectionInputFilter::class,
                'required' => true,
                'count' => 1,
                'input_filter' => array(
                    'type' => Zend\InputFilter\InputFilter::class,
                    'name' => 'FooBar',
                    'required' => true,
                    'filters' => array(),
                    'validators' => array(),
                ),
            ),
        ),
    ),
);
```

this pull request fixes api doc generation for collections.
