### PR TITLE
fixed typo Zend\View\Modle\ViewModel in Zend\View\Model\ViewModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ MVC application.
 namespace ZF\Apigility\Documentation;
 
 use Zend\ServiceManager\Factory\InvokableFactory;
-use Zend\View\Modle\ViewModel;
+use Zend\View\Model\ViewModel;
 
 return [
     'router' => [

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -7,7 +7,7 @@
 namespace ZF\Apigility\Documentation;
 
 use Zend\ServiceManager\Factory\InvokableFactory;
-use Zend\View\Modle\ViewModel;
+use Zend\View\Model\ViewModel;
 
 return [
     'router' => [


### PR DESCRIPTION
Fixes Error thrown Zend\Mvc\Exception\InvalidArgumentException "The supplied View Model could not be found"