### PR TITLE
bug-fix: rendering of nested collections

### DIFF
--- a/src/ApiFactory.php
+++ b/src/ApiFactory.php
@@ -359,13 +359,12 @@ class ApiFactory
         $flatFields = [];
 
         foreach ($fields as $idx => $field) {
-            if (isset($field['type'])
+            if (isset($field['type'], $field['input_filter'])
                 && ($field['type'] === CollectionInputFilter::class
                     || is_subclass_of($field['type'], CollectionInputFilter::class))
-                && isset($field['input_filter'])
             ) {
                 $filteredFields = array_diff_key($field['input_filter'], ['type' => 0]);
-                $fullindex = $prefix ? sprintf('%s[]/%s', $prefix, $idx) : $idx . '[]';
+                $fullindex = $prefix ? sprintf('%s/%s[]', $prefix, $idx) : $idx . '[]';
                 $flatFields = array_merge($flatFields, $this->mapFields($filteredFields, $fullindex));
                 continue;
             }

--- a/src/Service.php
+++ b/src/Service.php
@@ -235,7 +235,7 @@ class Service implements IteratorAggregate
     }
 
     /**
-     * @return array
+     * @return Field[]
      */
     public function getFields($type)
     {

--- a/test/ApiFactoryTest.php
+++ b/test/ApiFactoryTest.php
@@ -9,6 +9,7 @@ namespace ZFTest\Apigility\Documentation;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\ModuleManager\ModuleManager;
 use ZF\Apigility\Documentation\ApiFactory;
+use ZF\Apigility\Documentation\Service;
 use ZF\Apigility\Provider\ApigilityProviderInterface;
 use ZF\Configuration\ModuleUtils;
 
@@ -142,7 +143,7 @@ class ApiFactoryTest extends TestCase
 
         $this->assertEquals('Test', $api->getName());
         $this->assertEquals(1, $api->getVersion());
-        $this->assertCount(6, $api->getServices());
+        $this->assertCount(7, $api->getServices());
     }
 
     public function testCreateRestService()
@@ -235,6 +236,37 @@ class ApiFactoryTest extends TestCase
 
         $this->assertSame('FooBarCollection[]/FooBar', $fields[0]->getName());
         $this->assertSame('AnotherCollection[]/FooBar', $fields[1]->getName());
+    }
+
+    public function testCreateRestArtistsService()
+    {
+        $docConfig = include __DIR__ . '/TestAsset/module-config/documentation.config.php';
+
+        $api = $this->apiFactory->createApi('Test', 1);
+
+        $service = $this->apiFactory->createService($api, 'Bands');
+        self::assertInstanceOf(Service::class, $service);
+
+        self::assertEquals('Bands', $service->getName());
+        self::assertEquals(
+            $docConfig['Test\V1\Rest\Bands\Controller']['description'],
+            $service->getDescription()
+        );
+
+        $fields = $service->getFields('input_filter');
+        self::assertCount(11, $fields);
+
+        self::assertSame('name', $fields[0]->getName());
+        self::assertSame('artists[]/first_name', $fields[1]->getName());
+        self::assertSame('artists[]/last_name', $fields[2]->getName());
+        self::assertSame('debut_album/title', $fields[3]->getName());
+        self::assertSame('debut_album/release_date', $fields[4]->getName());
+        self::assertSame('debut_album/tracks[]/number', $fields[5]->getName());
+        self::assertSame('debut_album/tracks[]/title', $fields[6]->getName());
+        self::assertSame('albums[]/title', $fields[7]->getName());
+        self::assertSame('albums[]/release_date', $fields[8]->getName());
+        self::assertSame('albums[]/tracks[]/number', $fields[9]->getName());
+        self::assertSame('albums[]/tracks[]/title', $fields[10]->getName());
     }
 
     public function testCreateRpcService()

--- a/test/TestAsset/module-config/documentation.config.php
+++ b/test/TestAsset/module-config/documentation.config.php
@@ -86,4 +86,7 @@ return [
         ],
         'description' => 'Ping the API',
     ],
+    'Test\\V1\\Rest\\Bands\\Controller' => [
+        'description' => 'A REST service about our favorite musical Bands.',
+    ],
 ];

--- a/test/TestAsset/module-config/module.config.php
+++ b/test/TestAsset/module-config/module.config.php
@@ -64,6 +64,15 @@ return [
                     ],
                 ],
             ],
+            'test.rest.bands' => [
+                'type' => 'Segment',
+                'options' => [
+                    'route' => '/bands[/:band_id]',
+                    'defaults' => [
+                        'controller' => 'Test\\V1\\Rest\\Bands\\Controller',
+                    ],
+                ],
+            ],
         ],
     ],
     'zf-versioning' => [
@@ -80,6 +89,7 @@ return [
             'Test\\V1\\Rest\\FooBar\\FooBarResource' => 'Test\\V1\\Rest\\FooBar\\FooBarResource',
             'Test\\V1\\Rest\\FooBarCollection\\FooBarResource' => 'Test\\V1\\Rest\\FooBarCollection\\FooBarResource',
             'Test\\V1\\Rest\\BooBaz\\BooBazResource' => 'Test\\V1\\Rest\\BooBaz\\BooBazResource',
+            'Test\\V1\\Rest\\Bands\\BandsResource' => 'Test\\V1\\Rest\\Bands\\BandsResource',
         ],
     ],
     'zf-rest' => [
@@ -166,6 +176,28 @@ return [
             'collection_class' => 'Test\\V1\\Rest\\EntityFields\\EntityFieldsCollection',
             'service_name' => 'EntityFields',
         ],
+        'Test\\V1\\Rest\\Bands\\Controller' => [
+            'listener' => 'Test\\V1\\Rest\\Bands\\BandsResource',
+            'route_name' => 'test.rest.bands',
+            'route_identifier_name' => 'artist_id',
+            'collection_name' => 'foo_bar',
+            'entity_http_methods' => [
+                0 => 'GET',
+                1 => 'PATCH',
+                2 => 'PUT',
+                3 => 'DELETE',
+            ],
+            'collection_http_methods' => [
+                0 => 'GET',
+                1 => 'POST',
+            ],
+            'collection_query_whitelist' => [],
+            'page_size' => 25,
+            'page_size_param' => null,
+            'entity_class' => 'Test\\V1\\Rest\\Bands\\ArtistEntity',
+            'collection_class' => 'Test\\V1\\Rest\\Bands\\ArtistCollection',
+            'service_name' => 'Bands',
+        ],
     ],
     'zf-content-negotiation' => [
         'controllers' => [
@@ -174,6 +206,7 @@ return [
             'Test\\V1\\Rest\\BooBaz\\Controller' => 'HalJson',
             'Test\\V1\\Rpc\\MyRpc\\Controller' => 'Json',
             'Test\\V1\\Rpc\\Ping\\Controller' => 'Json',
+            'Test\\V1\\Rest\\Bands\\Controller' => 'HalJson',
         ],
         'accept_whitelist' => [
             'Test\\V1\\Rest\\FooBar\\Controller' => [
@@ -206,6 +239,11 @@ return [
                 1 => 'application/json',
                 2 => 'application/*+json',
             ],
+            'Test\\V1\\Rest\\Bands\\Controller' => [
+                0 => 'application/vnd.test.v1+json',
+                1 => 'application/hal+json',
+                2 => 'application/json',
+            ],
         ],
         'content_type_whitelist' => [
             'Test\\V1\\Rest\\FooBar\\Controller' => [
@@ -229,6 +267,10 @@ return [
                 1 => 'application/json',
             ],
             'Test\\V1\\Rpc\\EntityFields\\Controller' => [
+                0 => 'application/vnd.test.v1+json',
+                1 => 'application/json',
+            ],
+            'Test\\V1\\Rest\\Bands\\Controller' => [
                 0 => 'application/vnd.test.v1+json',
                 1 => 'application/json',
             ],
@@ -266,6 +308,12 @@ return [
                 'route_identifier_name' => 'id',
                 'is_collection' => true,
             ],
+            'Test\\V1\\Rest\\Bands\\ArtistEntity' => [
+                'entity_identifier_name' => 'id',
+                'route_name' => 'test.rest.bands',
+                'route_identifier_name' => 'artist_id',
+                'hydrator' => 'Zend\\Hydrator\\ArraySerializable',
+            ],
         ],
     ],
     'controllers' => [
@@ -300,6 +348,9 @@ return [
         'Test\\V1\\Rest\\EntityFields\\Controller' => [
             'input_filter' => 'Test\\V1\\Rest\\EntityFields\\Validator',
             'PUT' => 'Test\\V1\\Rest\\EntityFields\\Validator\\Put',
+        ],
+        'Test\\V1\\Rest\\Bands\\Controller' => [
+            'input_filter' => 'Test\\V1\\Rest\\Bands\\Validator',
         ],
     ],
     'input_filter_specs' => [
@@ -405,6 +456,90 @@ return [
                 'filters' => [],
                 'name' => 'test_put',
                 'description' => 'test_put',
+            ],
+        ],
+        'Test\\V1\\Rest\\Bands\\Validator' => [
+            [
+                'name' => 'name',
+                'required' => true,
+                'description' => 'The name of the Band.',
+            ],
+            'artists' => [
+                'type' => Zend\InputFilter\CollectionInputFilter::class,
+                'input_filter' => [
+                    'type' => \Zend\InputFilter\InputFilter::class,
+                    'first_name' => [
+                        'name' => 'first_name',
+                        'required' => true,
+                        'description' => 'The Artist\'s first name.',
+                    ],
+                    'last_name' => [
+                        'name' => 'last_name',
+                        'required' => true,
+                        'description' => 'The Artist\'s last name.',
+                    ],
+                ],
+            ],
+            'debut_album' => [
+                'type' => \Zend\InputFilter\InputFilter::class,
+                'title' => [
+                    'name' => 'title',
+                    'required' => true,
+                    'description' => 'Album title.',
+                ],
+                'release_date' => [
+                    'name' => 'release_date',
+                    'required' => true,
+                    'description' => 'Album release date.',
+                ],
+                'tracks' => [
+                    'type' => Zend\InputFilter\CollectionInputFilter::class,
+                    'input_filter' => [
+                        'type' => \Zend\InputFilter\InputFilter::class,
+                        'number' => [
+                            'name' => 'number',
+                            'required' => true,
+                            'description' => 'Track number.',
+                        ],
+                        'title' => [
+                            'name' => 'title',
+                            'required' => true,
+                            'description' => 'Track title.',
+                        ],
+                    ],
+                ],
+            ],
+            'albums' => [
+                'type' => Zend\InputFilter\CollectionInputFilter::class,
+                'input_filter' => [
+                    'type' => \Zend\InputFilter\InputFilter::class,
+                    'title' => [
+                        'name' => 'title',
+                        'required' => true,
+                        'description' => 'Album title.',
+                    ],
+                    'release_date' => [
+                        'name' => 'release_date',
+                        'required' => true,
+                        'description' => 'Album release date.',
+                    ],
+                    'tracks' => [
+                        'type' => Zend\InputFilter\CollectionInputFilter::class,
+                        'input_filter' => [
+                            'type' => \Zend\InputFilter\InputFilter::class,
+                            'number' => [
+                                'name' => 'number',
+                                'required' => true,
+                                'description' => 'Track number.',
+                            ],
+                            'title' => [
+                                'name' => 'title',
+                                'required' => true,
+                                'description' => 'Track title.',
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ],
     ],


### PR DESCRIPTION
add a new test service with lots of nested attributes and collections to demonstrate the representation of collections at any level in the input filter spec as "[]" instead of "/input_filter/". previous implementation did not handle multi-level at all and generated misleading documentation (sorry about that everyone! my bad.).

@weierophinney thank you so much for accepting my previous merge request #39. unfortunately my new tests were a bit too shallow and i've identified a missing test case.

i've added a new scenario, with an Artist+Album theme. the test service i've documented includes a Band that has a name, Artists with names, a collection of Albums each with collections of Tracks, and finally a single debut Album with a collection of Tracks.

documentation for this service should look like this:
```
name
artists[]/first_name
artists[]/last_name
debut_album/title
debut_album/release_date
debut_album/tracks[]/number
debut_album/tracks[]/title
albums[]/title
albums[]/release_date
albums[]/tracks[]/number
albums[]/tracks[]/title
``` 

my proposed changes ensure this, while the current implementation incorrectly produces the following:
```
artists[]/first_name
artists[]/last_name
debut_album/title
debut_album/release_date
debut_album[]/tracks/number
debut_album[]/tracks/title
albums[]/title
albums[]/release_date
albums[][]/tracks/number
albums[][]/tracks/title
```

it's obvious when you look at `debut_album[]/tracks` and `albums[][]/tracks` that we have an issue. the existing test service and test are left intact because they are valid, they just don't cover the specific cases i've identified here.

thanks for taking a look.