### PR TITLE
bug-fix: escapeTransformDescription is not a service/helper. replaced with agT…

### DIFF
--- a/view/zf-apigility-documentation/operation.phtml
+++ b/view/zf-apigility-documentation/operation.phtml
@@ -38,7 +38,7 @@ $collapseId        = $this->escapeHtmlAttr(sprintf('ops-collapse-%s-%s%s', $serv
                             <tr>
                                 <td><?php echo $this->escapeHtml($field->getName()) ?></td>
                                 <td><?php echo $this->escapeHtml($field->getFieldType() ?: '') ?></td>
-                                <td><?php echo $this->escapeTransformDescription($field->getDescription()) ?></td>
+                                <td><?php echo $this->agTransformDescription($field->getDescription()) ?></td>
                                 <td class="center-block"><span class="badge"><?php echo ($field->isRequired()) ? 'YES' : 'NO' ?></span></td>
                             </tr>
                         <?php


### PR DESCRIPTION
`escapeTransformDescription` is not a service/helper. replaced with `agTransformDescription`.

this is the error i see on `/apigility/documentation/MyApi-v1` without this change:
```
An error occurred
An error occurred during execution; please try again later.
Additional information:
Zend\ServiceManager\Exception\ServiceNotFoundException
File:
/vagrant/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:555
Message:
Zend\View\HelperPluginManager::get was unable to fetch or create an instance for escapeTransformDescription
Stack trace:
#0 /vagrant/vendor/zendframework/zend-servicemanager/src/AbstractPluginManager.php(161): Zend\ServiceManager\ServiceManager->get('escapeTransform...', true)
#1 /vagrant/vendor/zendframework/zend-view/src/Renderer/PhpRenderer.php(373): Zend\ServiceManager\AbstractPluginManager->get('escapeTransform...', NULL)
#2 /vagrant/vendor/zendframework/zend-view/src/Renderer/PhpRenderer.php(391): Zend\View\Renderer\PhpRenderer->plugin('escapeTransform...')
#3 /vagrant/vendor/zfcampus/zf-apigility-documentation/view/zf-apigility-documentation/operation.phtml(41): Zend\View\Renderer\PhpRenderer->__call('escapeTransform...', Array)
#4 /vagrant/vendor/zfcampus/zf-apigility-documentation/view/zf-apigility-documentation/operation.phtml(41): Zend\View\Renderer\PhpRenderer->escapeTransformDescription('Filter by facil...')
#5 /vagrant/vendor/zendframework/zend-view/src/Renderer/PhpRenderer.php(502): include('/vagrant/vendor...')
#6 /vagrant/vendor/zfcampus/zf-apigility-documentation/view/zf-apigility-documentation/service.phtml(25): Zend\View\Renderer\PhpRenderer->render('zf-apigility-do...', Array)
#7 /vagrant/vendor/zendframework/zend-view/src/Renderer/PhpRenderer.php(502): include('/vagrant/vendor...')
#8 /vagrant/vendor/zfcampus/zf-apigility-documentation/view/zf-apigility-documentation/api.phtml(15): Zend\View\Renderer\PhpRenderer->render('zf-apigility-do...', Array)
#9 /vagrant/vendor/zendframework/zend-view/src/Renderer/PhpRenderer.php(502): include('/vagrant/vendor...')
#10 /vagrant/vendor/zfcampus/zf-apigility-documentation/view/zf-apigility-documentation/show.phtml(6): Zend\View\Renderer\PhpRenderer->render('zf-apigility-do...', Array)
#11 /vagrant/vendor/zendframework/zend-view/src/Renderer/PhpRenderer.php(502): include('/vagrant/vendor...')
#12 /vagrant/vendor/zendframework/zend-view/src/View.php(207): Zend\View\Renderer\PhpRenderer->render(Object(Zend\View\Model\ViewModel))
#13 /vagrant/vendor/zendframework/zend-view/src/View.php(236): Zend\View\View->render(Object(Zend\View\Model\ViewModel))
#14 /vagrant/vendor/zendframework/zend-view/src/View.php(200): Zend\View\View->renderChildren(Object(Zend\View\Model\ViewModel))
#15 /vagrant/vendor/zendframework/zend-mvc/src/View/Http/DefaultRenderingStrategy.php(105): Zend\View\View->render(Object(Zend\View\Model\ViewModel))
#16 [internal function]: Zend\Mvc\View\Http\DefaultRenderingStrategy->render(Object(Zend\Mvc\MvcEvent))
#17 /vagrant/vendor/zendframework/zend-eventmanager/src/EventManager.php(490): call_user_func(Array, Object(Zend\Mvc\MvcEvent))
#18 /vagrant/vendor/zendframework/zend-eventmanager/src/EventManager.php(251): Zend\EventManager\EventManager->triggerListeners('render', Object(Zend\Mvc\MvcEvent))
#19 /vagrant/vendor/zendframework/zend-mvc/src/Application.php(384): Zend\EventManager\EventManager->triggerEvent(Object(Zend\Mvc\MvcEvent))
#20 /vagrant/vendor/zendframework/zend-mvc/src/Application.php(356): Zend\Mvc\Application->completeRequest(Object(Zend\Mvc\MvcEvent))
#21 /vagrant/public/index.php(53): Zend\Mvc\Application->run()
#22 {main}
```

@bgaillard can you weigh in here? changing `escapeTransformDescription` to `agTransformDescription` resolves the issue and seems to match the rest of your changes in #35. 